### PR TITLE
Setting zindex to newly created objects

### DIFF
--- a/src/BottomBarTools/DuplicateTool/index.tsx
+++ b/src/BottomBarTools/DuplicateTool/index.tsx
@@ -6,7 +6,11 @@ import {
   ReactDrawContext,
 } from "../../types";
 import { DuplicateIcon } from "@jzohdi/jsx-icons";
-import { getObjectFromMap, getToolById } from "../../utils/utils";
+import {
+  getCurrentHighestZIndex,
+  getObjectFromMap,
+  getToolById,
+} from "../../utils/utils";
 import {
   getSelectedIdsFromFullState,
   selectElement,
@@ -88,17 +92,15 @@ function duplicateObject(
   const newDiv = div.cloneNode(true) as HTMLDivElement;
   const { newId, divId } = makeNewId(div.id);
   newDiv.id = divId;
-  const objectsToSelect = Array.from(ctx.objectsMap.values());
-  objectsToSelect.sort((a, b) => {
-    return parseInt(b.containerDiv.style.zIndex) -  parseInt(a.containerDiv.style.zIndex)
-  });
-  let nextZIndex = objectsToSelect[0]?.containerDiv.style.zIndex === undefined ? 0 : parseInt(objectsToSelect[0].containerDiv.style.zIndex) + 1;
+  const currentMaxZindex = getCurrentHighestZIndex(ctx);
+  const nextZindex = currentMaxZindex + 1;
   const data: DrawingData = {
     coords: object.coords.slice(0),
     toolId: object.toolId,
     element: newDiv.lastElementChild as HTMLElement,
     style: {
       ...object.style,
+      zIndex: nextZindex.toString(),
     },
     customData: new Map(object.customData),
     containerDiv: newDiv,
@@ -107,7 +109,7 @@ function duplicateObject(
   const bbox = getBoxSize(object);
   newDiv.style.top = bbox.top + 5 + "px";
   newDiv.style.left = bbox.left + 10 + "px";
-  newDiv.style.zIndex = nextZIndex.toString();
+  newDiv.style.zIndex = nextZindex.toString();
   const tool = getToolById(ctx.drawingTools, object.toolId);
   if (tool.onDuplicate) {
     return tool.onDuplicate(data, ctx);

--- a/src/BottomBarTools/DuplicateTool/index.tsx
+++ b/src/BottomBarTools/DuplicateTool/index.tsx
@@ -88,6 +88,11 @@ function duplicateObject(
   const newDiv = div.cloneNode(true) as HTMLDivElement;
   const { newId, divId } = makeNewId(div.id);
   newDiv.id = divId;
+  const objectsToSelect = Array.from(ctx.objectsMap.values());
+  objectsToSelect.sort((a, b) => {
+    return parseInt(b.containerDiv.style.zIndex) -  parseInt(a.containerDiv.style.zIndex)
+  });
+  let nextZIndex = objectsToSelect[0]?.containerDiv.style.zIndex === undefined ? 0 : parseInt(objectsToSelect[0].containerDiv.style.zIndex) + 1;
   const data: DrawingData = {
     coords: object.coords.slice(0),
     toolId: object.toolId,
@@ -102,7 +107,7 @@ function duplicateObject(
   const bbox = getBoxSize(object);
   newDiv.style.top = bbox.top + 5 + "px";
   newDiv.style.left = bbox.left + 10 + "px";
-
+  newDiv.style.zIndex = nextZIndex.toString();
   const tool = getToolById(ctx.drawingTools, object.toolId);
   if (tool.onDuplicate) {
     return tool.onDuplicate(data, ctx);

--- a/src/ReactDraw/ReactDraw.tsx
+++ b/src/ReactDraw/ReactDraw.tsx
@@ -21,6 +21,7 @@ import { getNumFrom, makeNewBoundingDiv } from "../utils";
 import { BottomToolBar } from "./BottomToolBar";
 import { ERASE_TOOL_ID, SELECT_TOOL_ID } from "../constants";
 import {
+	getCurrentHighestZIndex,
   getObjectFromMap,
   getRelativePoint,
   getTouchCoords,
@@ -205,16 +206,13 @@ export default function ReactDraw({
   function starDraw(relativePoint: Point) {
     const ctx = getReactDrawContext();
     const styles = { ...globalStyles.current };
-    const objectsToSelect = Array.from(ctx.objectsMap.values());
-    objectsToSelect.sort((a, b) => {
-      return parseInt(b.containerDiv.style.zIndex) -  parseInt(a.containerDiv.style.zIndex)
-    });
-    let nextZIndex = objectsToSelect[0]?.containerDiv.style.zIndex === undefined ? 0 : parseInt(objectsToSelect[0].containerDiv.style.zIndex) + 1;
+		const currentMaxZindex = getCurrentHighestZIndex(ctx);
+		const nextZindex = currentMaxZindex + 1;
+		styles.zIndex = nextZindex.toString()
     const newDrawingData = makeNewBoundingDiv(
       relativePoint,
       styles,
       currentDrawingTool.id,
-      nextZIndex
     );
     currDrawObj.current = newDrawingData;
     ctx.viewContainer.append(newDrawingData.containerDiv);

--- a/src/ReactDraw/ReactDraw.tsx
+++ b/src/ReactDraw/ReactDraw.tsx
@@ -203,7 +203,7 @@ export default function ReactDraw({
    */
 
   
-  function starDraw(relativePoint: Point) {
+  function startDraw(relativePoint: Point) {
     const ctx = getReactDrawContext();
     const styles = { ...globalStyles.current };
 		const currentMaxZindex = getCurrentHighestZIndex(ctx);
@@ -257,7 +257,7 @@ export default function ReactDraw({
       latestEvent.current = e;
       const startPoint: Point = [e.clientX, e.clientY];
       const relativePoint = getRelativePoint(startPoint, container);
-      starDraw(relativePoint);
+      startDraw(relativePoint);
     }
 
     function drawMouse(e: MouseEvent) {
@@ -279,7 +279,7 @@ export default function ReactDraw({
       e.preventDefault();
       const startPoint = getTouchCoords(e);
       const relativePoint = getRelativePoint(startPoint, container);
-      starDraw(relativePoint);
+      startDraw(relativePoint);
     }
 
     function drawTouch(e: TouchEvent) {

--- a/src/ReactDraw/ReactDraw.tsx
+++ b/src/ReactDraw/ReactDraw.tsx
@@ -200,15 +200,21 @@ export default function ReactDraw({
    * @param relativePoint a point [x, y] relative to the drawing area box
    * @returns
    */
+
+  
   function starDraw(relativePoint: Point) {
     const ctx = getReactDrawContext();
     const styles = { ...globalStyles.current };
-    const objMapSize = ctx.objectsMap.size;
+    const objectsToSelect = Array.from(ctx.objectsMap.values());
+    objectsToSelect.sort((a, b) => {
+      return parseInt(b.containerDiv.style.zIndex) -  parseInt(a.containerDiv.style.zIndex)
+    });
+    let nextZIndex = objectsToSelect[0]?.containerDiv.style.zIndex === undefined ? 0 : parseInt(objectsToSelect[0].containerDiv.style.zIndex) + 1;
     const newDrawingData = makeNewBoundingDiv(
       relativePoint,
       styles,
       currentDrawingTool.id,
-      objMapSize
+      nextZIndex
     );
     currDrawObj.current = newDrawingData;
     ctx.viewContainer.append(newDrawingData.containerDiv);

--- a/src/ReactDraw/ReactDraw.tsx
+++ b/src/ReactDraw/ReactDraw.tsx
@@ -203,10 +203,12 @@ export default function ReactDraw({
   function starDraw(relativePoint: Point) {
     const ctx = getReactDrawContext();
     const styles = { ...globalStyles.current };
+    const objMapSize = ctx.objectsMap.size;
     const newDrawingData = makeNewBoundingDiv(
       relativePoint,
       styles,
-      currentDrawingTool.id
+      currentDrawingTool.id,
+      objMapSize
     );
     currDrawObj.current = newDrawingData;
     ctx.viewContainer.append(newDrawingData.containerDiv);
@@ -557,6 +559,7 @@ const defaultEditableProps: ToolPropertiesMap = {
 };
 // TODO: accept default styles as a react-draw prop
 function setupGlobalStyles(topBarTools: DrawingTools[]) {
+  
   const styles: ToolPropertiesMap = {
     ...defaultEditableProps,
   };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -27,21 +27,22 @@ export function isBrowser() {
 export function makeNewBoundingDiv(
   relativePoint: Point,
   globalStyles: ToolPropertiesMap,
-  toolId: string
+  toolId: string,
+  zIndex: number
 ): DrawingData {
   if (!isBrowser()) {
     throw new Error("new bounding div called on the server.");
   }
   const lineWidth = parseInt(globalStyles.lineWidth);
   const [pointX, pointY] = relativePoint;
-  const { id, div } = makeNewDiv(pointX, pointY, lineWidth, toolId);
+  const { id, div } = makeNewDiv(pointX, pointY, lineWidth, toolId, zIndex);
   const data: DrawingData = {
     coords: [relativePoint],
     element: null,
     toolId,
     containerDiv: div,
     id,
-    style: globalStyles,
+    style: {...globalStyles, zIndex: zIndex.toString()},
     customData: new Map(),
   };
   return data;
@@ -60,7 +61,8 @@ export function makeNewDiv(
   pointX: number,
   pointY: number,
   lineWidth: number,
-  toolId: string
+  toolId: string,
+  zIndex: number
 ): MakeNewDivOutput {
   const id = makeid(6);
   const div = document.createElement("div");
@@ -73,7 +75,7 @@ export function makeNewDiv(
   div.style.left = left + "px";
   div.style.top = top + "px";
   div.style.pointerEvents = "none";
-  div.style.zIndex = "1";
+  div.style.zIndex = zIndex.toString();
   div.style.boxSizing = "border-box";
   return {
     div,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -26,23 +26,23 @@ export function isBrowser() {
 
 export function makeNewBoundingDiv(
   relativePoint: Point,
-  globalStyles: ToolPropertiesMap,
-  toolId: string,
-  zIndex?: number
+  stylesToInitialize: ToolPropertiesMap,
+  toolId: string
 ): DrawingData {
   if (!isBrowser()) {
     throw new Error("new bounding div called on the server.");
   }
-  const lineWidth = parseInt(globalStyles.lineWidth);
+  const lineWidth = parseInt(stylesToInitialize.lineWidth);
+  const zIndex = parseInt(stylesToInitialize.zIndex ?? "0");
   const [pointX, pointY] = relativePoint;
-  const { id, div } = makeNewDiv(pointX, pointY, lineWidth, toolId, zIndex || 1);
+  const { id, div } = makeNewDiv(pointX, pointY, lineWidth, toolId, zIndex);
   const data: DrawingData = {
     coords: [relativePoint],
     element: null,
     toolId,
     containerDiv: div,
     id,
-    style: {...globalStyles, zIndex: zIndex?.toString() || "1"},
+    style: { ...stylesToInitialize },
     customData: new Map(),
   };
   return data;
@@ -62,7 +62,7 @@ export function makeNewDiv(
   pointY: number,
   lineWidth: number,
   toolId: string,
-  zIndex?: number
+  zIndex: number
 ): MakeNewDivOutput {
   const id = makeid(6);
   const div = document.createElement("div");
@@ -75,7 +75,7 @@ export function makeNewDiv(
   div.style.left = left + "px";
   div.style.top = top + "px";
   div.style.pointerEvents = "none";
-  div.style.zIndex = zIndex?.toString() || "1";
+  div.style.zIndex = zIndex.toString();
   div.style.boxSizing = "border-box";
   return {
     div,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -28,21 +28,21 @@ export function makeNewBoundingDiv(
   relativePoint: Point,
   globalStyles: ToolPropertiesMap,
   toolId: string,
-  zIndex: number
+  zIndex?: number
 ): DrawingData {
   if (!isBrowser()) {
     throw new Error("new bounding div called on the server.");
   }
   const lineWidth = parseInt(globalStyles.lineWidth);
   const [pointX, pointY] = relativePoint;
-  const { id, div } = makeNewDiv(pointX, pointY, lineWidth, toolId, zIndex);
+  const { id, div } = makeNewDiv(pointX, pointY, lineWidth, toolId, zIndex || 1);
   const data: DrawingData = {
     coords: [relativePoint],
     element: null,
     toolId,
     containerDiv: div,
     id,
-    style: {...globalStyles, zIndex: zIndex.toString()},
+    style: {...globalStyles, zIndex: zIndex?.toString() || "1"},
     customData: new Map(),
   };
   return data;
@@ -62,7 +62,7 @@ export function makeNewDiv(
   pointY: number,
   lineWidth: number,
   toolId: string,
-  zIndex: number
+  zIndex?: number
 ): MakeNewDivOutput {
   const id = makeid(6);
   const div = document.createElement("div");
@@ -75,7 +75,7 @@ export function makeNewDiv(
   div.style.left = left + "px";
   div.style.top = top + "px";
   div.style.pointerEvents = "none";
-  div.style.zIndex = zIndex.toString();
+  div.style.zIndex = zIndex?.toString() || "1";
   div.style.boxSizing = "border-box";
   return {
     div,

--- a/src/utils/readStyles.ts
+++ b/src/utils/readStyles.ts
@@ -12,3 +12,7 @@ export function getScaleFromSvg(data: DrawingData) {
   }
   return { x: scale[0], y: scale[1] };
 }
+
+export function getZindexFromDiv(div: HTMLDivElement) {
+  return div.style.zIndex === undefined ? 0 : parseInt(div.style.zIndex);
+}

--- a/src/utils/serialization.ts
+++ b/src/utils/serialization.ts
@@ -193,7 +193,14 @@ export function deserializationSetup(obj: IntermediateStringableObject) {
   const customData = freeDrawObj.customData;
   const p = freeDrawObj.coords[0];
   const lineWidth = parseInt(freeDrawObj.style.lineWidth);
-  const { id, div } = makeNewDiv(p[0], p[1], lineWidth, freeDrawObj.toolId);
+  const zIndex = parseInt(freeDrawObj.style.zIndex ?? "0");
+  const { id, div } = makeNewDiv(
+    p[0],
+    p[1],
+    lineWidth,
+    freeDrawObj.toolId,
+    zIndex
+  );
   const drawingData: DrawingData = {
     toolId: freeDrawObj.toolId,
     id,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -176,14 +176,24 @@ export function createNewObject(
   toolId: string
 ): DrawingData {
   const styles = { ...ctx.globalStyles };
-  const newData = makeNewBoundingDiv(point, styles, toolId);
+  const objectsToSelect = Array.from(ctx.objectsMap.values());
+  objectsToSelect.sort((a, b) => {
+    return parseInt(b.containerDiv.style.zIndex) -  parseInt(a.containerDiv.style.zIndex)
+  });
+  let nextZIndex = objectsToSelect[0]?.containerDiv.style.zIndex === undefined ? 0 : parseInt(objectsToSelect[0].containerDiv.style.zIndex) + 1;
+  const newData = makeNewBoundingDiv(point, styles, toolId, nextZIndex);
   return newData;
 }
 
 export function addObject(ctx: ReactDrawContext, obj: DrawingData): void {
   const { containerDiv, id } = obj;
   ctx.viewContainer.appendChild(containerDiv);
-  obj.style.zIndex = ctx.objectsMap.size.toString();
+  const objectsToSelect = Array.from(ctx.objectsMap.values());
+  objectsToSelect.sort((a, b) => {
+    return parseInt(b.containerDiv.style.zIndex) -  parseInt(a.containerDiv.style.zIndex)
+  });
+  let nextZIndex = objectsToSelect[0]?.containerDiv.style.zIndex === undefined ? 0 : parseInt(objectsToSelect[0].containerDiv.style.zIndex) + 1;
+  obj.style.zIndex = nextZIndex.toString();
   ctx.objectsMap.set(id, obj);
 }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -183,6 +183,7 @@ export function createNewObject(
 export function addObject(ctx: ReactDrawContext, obj: DrawingData): void {
   const { containerDiv, id } = obj;
   ctx.viewContainer.appendChild(containerDiv);
+  obj.style.zIndex = ctx.objectsMap.size.toString();
   ctx.objectsMap.set(id, obj);
 }
 


### PR DESCRIPTION
For layering optimization within MindBody -- ideally we would want the most recently added object to be the first to be selected. 

The logic is to find the current largest zIndex within ctx.objectsMap and then increasing the zIndex by 1 for the newly created object within the methods where we are
1) Creating objects (such as adding text/images/shapes) 
2) Directly using Drawing Tools that exist in the Top Bar Container to add a new shape within our canvas
3) Duplicating objects (we would like the duplicated object to have a higher zIndex I believe)

I can probably consolidate this logic to a single helper function so that I don't have to repeat code but wanted to get some eyes on it first.

Manually testing the PR through the docs looks good -- when we inspect the elements on the canvas they are properly updating.

