### PR TITLE
Fix: prevent app crashes from rotation selection errors

### DIFF
--- a/src/utils/select/resizeHandler.ts
+++ b/src/utils/select/resizeHandler.ts
@@ -29,7 +29,7 @@ function startResizing(
     ctx.objectsMap
   );
   if (selectedObject.length !== 1) {
-    throw new Error("start rotating got incorrect number of objects to handle");
+    return;
   }
   const data = selectedObject[0];
   //   const pointDiff: Point = getPointDiff(relativePoint, prevPoint);

--- a/src/utils/select/resizeHandler.ts
+++ b/src/utils/select/resizeHandler.ts
@@ -29,6 +29,7 @@ function startResizing(
     ctx.objectsMap
   );
   if (selectedObject.length !== 1) {
+    console.error("start rotating got incorrect number of objects to handle");
     return;
   }
   const data = selectedObject[0];

--- a/src/utils/select/rotateHandler.ts
+++ b/src/utils/select/rotateHandler.ts
@@ -21,6 +21,7 @@ function startRotating(ctx: ReactDrawContext, relativePoint: Point) {
     ctx.objectsMap
   );
   if (selectedObject.length !== 1) {
+    console.error("start rotating got incorrect number of objects to handle");
     return;
   }
   const data = selectedObject[0];

--- a/src/utils/select/rotateHandler.ts
+++ b/src/utils/select/rotateHandler.ts
@@ -21,7 +21,7 @@ function startRotating(ctx: ReactDrawContext, relativePoint: Point) {
     ctx.objectsMap
   );
   if (selectedObject.length !== 1) {
-    throw new Error("start rotating got incorrect number of objects to handle");
+    return;
   }
   const data = selectedObject[0];
   const referenceCenter = getCenterPoint(getBoxSize(data));


### PR DESCRIPTION
Replace throw statements with early returns to handle invalid selection states gracefully instead of crashing the application.